### PR TITLE
feat: remove gl param from mesh constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ const normalMaterial = createNormalMaterial();
 ### Create a mesh and render
 
 ```js
-const mesh = new Mesh(renderer.gl, geometry, material);
+const mesh = new Mesh(geometry, material);
 
 // currently, the scene is just an array of meshes:
 const scene = [mesh];
@@ -96,7 +96,7 @@ camera.update();
 console.log('camera matrix:', cameraMatrix);
 console.log('view matrix:', viewMatrix);
 // the view matrix is the inverse of the camera matrix
-// you can pass these into the material.uniforms object, also accessible from the mesh.uniforms object.
+// you can pass these into the material.uniforms object.
 ```
 
 ### Perspective projection

--- a/src/webgl/renderer.ts
+++ b/src/webgl/renderer.ts
@@ -15,6 +15,9 @@ export class Renderer {
 
   render(scene: Mesh[]): Renderer {
     for (const obj of scene) {
+      // initialize the mesh for this rendering context
+      // if you need to reuse this mesh in another context, then dispose first
+      obj.init(this.gl);
       // render the thing.
       obj.enableAttribs();
       obj.draw();


### PR DESCRIPTION
- Remove GL parameter from mesh constructor
- Remove uniforms parameter from mesh constructor (it's only in the material now)
- Add possibility to specify the buffer usage strategy (gl.STATIC_DRAW or gl.DYNAMIC_DRAW)
- Add a method for buffer updates.

Heads up: this is a breaking API change.