### PR TITLE
Feat/merge geometries

### DIFF
--- a/src/geometries/buffer-geometry.test.ts
+++ b/src/geometries/buffer-geometry.test.ts
@@ -1,0 +1,95 @@
+import { BufferAttribute, BufferGeometry } from '.';
+import { createPlaneGeometry } from './plane';
+
+describe('BufferGeometry tests', () => {
+  test('createIndexedGeometry test', () => {
+    const plane = createPlaneGeometry(2, 2, 1, 1);
+    const indexedPlane = plane.createIndexedGeometry();
+    expect(indexedPlane.index).not.toBeNull();
+    expect(indexedPlane.indexType).toBe(16);
+    expect(indexedPlane.attributes.position.recordSize).toEqual(
+      plane.attributes.position.recordSize
+    );
+    expect(indexedPlane.attributes.position.data.length).toBe(
+      4 * indexedPlane.attributes.position.recordSize
+    );
+    expect(indexedPlane.count).toBe(6);
+    //prettier-ignore
+    expect(Array.from(indexedPlane.attributes.position.data)).toEqual([
+      -1, -1, 0, // bottom left
+       1, -1, 0, // bottom right
+      -1,  1, 0, // top left
+       1,  1, 0, // top right
+    ]);
+
+    // triangle vertices are arranged in a counter-clockwise way
+
+    //prettier-ignore
+    expect(indexedPlane.index).toEqual([
+      0, 1, 2, // triangle 1
+      1, 3, 2, // triangle 2
+    ]);
+  });
+
+  test('merging two non-indexed geometries', () => {
+    const plane1 = createPlaneGeometry(2, 2);
+    const plane2 = createPlaneGeometry(4, 4);
+    const merged = plane1.merge(plane2);
+    expect(merged.attributes.position).toBeDefined();
+    expect(merged.attributes.position.recordSize).toEqual(
+      plane1.attributes.position.recordSize
+    );
+    expect(merged.attributes.position.recordSize).toEqual(
+      plane2.attributes.position.recordSize
+    );
+    expect(merged.attributes.position.data.length).toBe(
+      merged.attributes.position.recordSize * 12
+    );
+    //prettier-ignore
+    expect(Array.from(merged.attributes.position.data)).toEqual([
+      // first plane
+      -1, -1, 0, // bottom left
+       1, -1, 0, // bottom right
+      -1,  1, 0, // top left
+       1, -1, 0, // bottom right
+       1,  1, 0, // top right
+      -1,  1, 0, // top left 
+      // second plane
+      -2, -2, 0, // bottom left
+       2, -2, 0, // bottom right
+      -2,  2, 0, // top left
+       2, -2, 0, // bottom right
+       2,  2, 0, // top right
+      -2,  2, 0, // top left
+    ]);
+  });
+
+  test('merging two indexed geometries', () => {
+    const triangle1 = new BufferGeometry();
+    const triangle2 = new BufferGeometry();
+    triangle1.setAttribute(
+      'position',
+      new BufferAttribute(new Float32Array([-1, -1, 1, -1, -1, 1]), 2)
+    );
+    //prettier-ignore
+    triangle2.setAttribute('position', new BufferAttribute(new Float32Array([ 
+       1, -1, 0, // bottom right
+       1,  1, 0, // top right
+      -1,  1, 0  // top left
+    ]), 3));
+    triangle1.setIndex([0, 1, 2]);
+    triangle2.setIndex([2, 1, 0]);
+    const merged = triangle1.merge(triangle2);
+    expect(merged.attributes.position.recordSize).toEqual(3);
+    //prettier-ignore
+    expect(Array.from(merged.attributes.position.data)).toEqual([
+      -1, -1, 0, // bottom left
+       1, -1, 0, // bottom right
+      -1,  1, 0, // top left
+       1, -1, 0, // bottom right
+       1,  1, 0, // top right
+      -1,  1, 0  // top left
+    ]);
+    expect(merged.index).toEqual([0, 1, 2, 5, 4, 3]);
+  });
+});

--- a/src/geometries/buffer-geometry.ts
+++ b/src/geometries/buffer-geometry.ts
@@ -45,6 +45,142 @@ export class BufferGeometry {
     return this;
   }
 
+  private static mergeNonIndexedGeometries(
+    a: BufferGeometry,
+    b: BufferGeometry
+  ): BufferGeometry {
+    const countA =
+      a.index !== null
+        ? a.count
+        : Math.max.apply(
+            null,
+            Object.values(a.attributes).map(
+              (attr) => (attr.data.length / attr.recordSize) | 0
+            )
+          );
+    const countB =
+      b.index !== null
+        ? b.count
+        : Math.max.apply(
+            null,
+            Object.values(b.attributes).map(
+              (attr) => (attr.data.length / attr.recordSize) | 0
+            )
+          );
+    const result = new BufferGeometry();
+    for (const key of Object.keys(a.attributes)) {
+      const newAttrib = [];
+      const attribA = a.attributes[key];
+      const attribB =
+        b.attributes[key] || new BufferAttribute(new Float32Array(a.count), 1);
+      const recordSize = Math.max(attribA.recordSize, attribB?.recordSize || 0);
+      for (let i = 0; i < countA; i++) {
+        for (let j = 0; j < recordSize; j++) {
+          if (
+            attribA.recordSize <= j ||
+            attribA.data.length <= i * attribA.recordSize + j
+          ) {
+            newAttrib.push(0);
+            continue;
+          }
+          newAttrib.push(a.attributes[key].data[i * attribA.recordSize + j]);
+        }
+      }
+      for (let i = 0; i < countB; i++) {
+        for (let j = 0; j < recordSize; j++) {
+          if (
+            !attribB ||
+            attribB.recordSize <= j ||
+            attribB.data.length <= i * attribB.recordSize + j
+          ) {
+            newAttrib.push(0);
+            continue;
+          }
+          newAttrib.push(b.attributes[key].data[i * attribB.recordSize + j]);
+        }
+      }
+      result.setAttribute(
+        key,
+        new BufferAttribute(new Float32Array(newAttrib), recordSize)
+      );
+    }
+    return result;
+  }
+
+  private static mergeIndexedGeometries(
+    a: BufferGeometry,
+    b: BufferGeometry
+  ): BufferGeometry {
+    if (a.index === null || b.index === null) {
+      throw Error();
+    }
+    const result = BufferGeometry.mergeNonIndexedGeometries(a, b);
+    const maxIndexA = Math.max.apply(null, a.index);
+    const maxIndexB = Math.max.apply(null, b.index);
+    const indices = a.index.concat(b.index.map((idx) => maxIndexA + 1 + idx));
+    result.setIndex(indices, maxIndexA + maxIndexB + 1 < 65534 ? 16 : 32);
+    return result;
+  }
+
+  merge(otherGeometry: BufferGeometry): BufferGeometry {
+    if (this.index === null && otherGeometry.index === null) {
+      return BufferGeometry.mergeNonIndexedGeometries(this, otherGeometry);
+    }
+    return BufferGeometry.mergeIndexedGeometries(
+      this.index === null ? this.createIndexedGeometry() : this,
+      otherGeometry.index === null
+        ? otherGeometry.createIndexedGeometry()
+        : otherGeometry
+    );
+  }
+
+  /**
+   * Create an indexed buffer geometry from a non-indexed one (might be expensive)
+   */
+  createIndexedGeometry(): BufferGeometry {
+    if (this.index !== null) {
+      throw Error('the buffer geometry is already indexed');
+    }
+    const result = new BufferGeometry();
+    const newAttribs: Record<string, number[]> = {};
+    const indices = [];
+    let lastIndex = -1;
+    const indexMap: Record<string, number> = {};
+    for (let i = 0; i < this.count; i++) {
+      const data: Record<string, number[]> = {};
+      for (const [key, attribute] of Object.entries(this.attributes)) {
+        const offset = i * attribute.recordSize;
+        data[key] = Array.from(
+          attribute.data.slice(offset, offset + attribute.recordSize)
+        );
+      }
+      const serialized = JSON.stringify(data);
+      if (indexMap[serialized]) {
+        const index = indexMap[serialized];
+        indices.push(index);
+      } else {
+        lastIndex++;
+        indexMap[serialized] = lastIndex;
+        indices.push(lastIndex);
+        for (const [key, value] of Object.entries(data)) {
+          if (!newAttribs[key]) {
+            newAttribs[key] = [];
+          }
+          Array.prototype.push.apply(newAttribs[key], value);
+        }
+      }
+    }
+    result.setIndex(indices, lastIndex > 65534 ? 32 : 16);
+    for (const [key, value] of Object.entries(newAttribs)) {
+      const recordSize = this.attributes[key].recordSize;
+      result.setAttribute(
+        key,
+        new BufferAttribute(new Float32Array(value), recordSize)
+      );
+    }
+    return result;
+  }
+
   dispose(): void {
     for (const attribute of Object.keys(this.attributes)) {
       this.removeAttribute(attribute);

--- a/src/webgl/mesh.ts
+++ b/src/webgl/mesh.ts
@@ -168,18 +168,19 @@ export class Mesh {
   }
 
   /**
-   * Update data of a single attribute
-   * @param attribName
-   * @param offset
-   * @param newData
-   * @param syncGeometry
+   * Update buffer of a single attribute
+   * @param attribName name of the attribute to be updated
+   * @param newData the new data
+   * @param offset offset (default = 0)
+   * @param syncGeometry also keep the underlying geometry data in sync (default = true)
+   * @returns current instance
    */
   updateBuffer(
     attribName: string,
-    offset: number,
     newData: Float32Array,
+    offset = 0,
     syncGeometry = true
-  ) {
+  ): Mesh {
     const { geometry, gl } = this;
     const buffer = this.buffers[attribName];
     if (syncGeometry) {
@@ -189,6 +190,7 @@ export class Mesh {
       gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
       gl.bufferSubData(gl.ARRAY_BUFFER, offset, newData);
     }
+    return this;
   }
 
   /**


### PR DESCRIPTION
- adds a `createIndexedGeometry()` method to `BufferGeometry` to create an indexed geometry from a non-indexed one
- adds `merge()` method to `BufferGeometry` to merge 2 geometries together.
- API changes for `Mesh.updateBuffer` 